### PR TITLE
Remove dead code comments from nix-darwin config

### DIFF
--- a/darwin-configuration.nix
+++ b/darwin-configuration.nix
@@ -123,8 +123,6 @@
               (builtins.readFile ./zshrc-snippets/homebrew.zsh)
               (builtins.readFile ./zshrc-snippets/java-android.zsh)
               (builtins.readFile ./zshrc-snippets/rust.zsh)
-#              (builtins.readFile ./zshrc-snippets/flutter.zsh)
-#              (builtins.readFile ./zshrc-snippets/ocaml.zsh)
               (builtins.readFile ./zshrc-snippets/vscode.zsh)
               (builtins.readFile ./zshrc-snippets/nix.zsh)
               (builtins.readFile ./zshrc-snippets/ruby.zsh)
@@ -133,185 +131,6 @@
               (builtins.readFile ./zshrc-snippets/nocommit.notion.zsh)
             ];
           };
-
-          /*vscode = {
-            # Want to only use this to control configuration.
-            # Still need to download vscode manually
-            enable = true;
-            profiles = {
-              default = {
-                userSettings = {
-                  "[typescript]" = {
-                    "editor.defaultFormatter" = "esbenp.prettier-vscode";
-                    "editor.formatOnSave" = true;
-                  };
-                  "[typescriptreact]" = {
-                    "editor.defaultFormatter" = "esbenp.prettier-vscode";
-                    "editor.formatOnSave" = true;
-                  };
-                  "[json]" = {
-                    "editor.defaultFormatter" = "esbenp.prettier-vscode";
-                  };
-                  "files.trimTrailingWhitespace" = true;
-                  "typescript.tsdk" = "./node_modules/typescript/lib";
-                };
-
-                keybindings = [
-                  {
-                    "key" = "ctrl+x 2";
-                    "command" = "workbench.action.splitEditorDown";
-                  }
-                  {
-                    "key" = "ctrl+x 3";
-                    "command" = "workbench.action.splitEditorRight";
-                  }
-                  {
-                    "key" = "ctrl+x ctrl+s";
-                    "command" = "workbench.action.files.save";
-                  }
-                  {
-                    "key" = "ctrl+alt+f";
-                    "command" = "cursorWordPartRight";
-                    "when" =  "textInputFocus";
-                  }
-                  {
-                    "key" = "ctrl+alt+b";
-                    "command" = "cursorWordPartLeft";
-                    "when" = "textInputFocus";
-                  }
-                  {
-                    "key" = "ctrl+k";
-                    "command" = "-deleteAllRight";
-                    "when" = "textInputFocus && !editorReadonly";
-                  }
-                  {
-                    "key" = "ctrl+y";
-                    "command" = "editor.action.clipboardPasteAction";
-                  }
-                  {
-                    "key" =  "ctrl+x space";
-                    "command" =  "workbench.action.gotoLine";
-                  }
-                ];
-                extensions = (with pkgs.vscode-extensions; [
-                  bbenoist.nix
-                ]) ++ pkgs.vscode-utils.extensionsFromVscodeMarketplace [
-                  {
-                    # taken from the package.json
-                    name = "vscode-cut-all-right";
-                    publisher = "cou929";
-                    version = "0.0.1";
-                    # install without this value, look at error message for calculated sha256.
-                    sha256 = "sha256-QBYOSklu1scLjMSQ2ZWFwr2+UoJMAZIxjeFdo5d67Lg=";
-                  }
-                  {
-                    # taken from the marketplace unique id: <publisher>.<name>
-                    name = "remote-ssh-edit";
-                    publisher = "ms-vscode-remote";
-                    version = "0.76.1"; #taken from marketplace UI
-                    # install without this value, look at error message for calculated sha256.
-                    sha256 = "sha256-VOl6l/4OXe7R+TznAKRgr8XU+CDp18qWC3y+K2bdC28=";
-                  }
-                  {
-                    # taken from the marketplace unique id: <publisher>.<name>
-                    name = "remote-ssh";
-                    publisher = "ms-vscode-remote";
-                    version = "0.76.1"; #taken from marketplace UI
-                    # install without this value, look at error message for calculated sha256.
-                    sha256 = "sha256-iLgGkf9hx75whXI+kmkmiGw3fnkEGp37Ae7GMdAz0+Y=";
-                  }
-                  {
-                    # taken from the marketplace unique id: <publisher>.<name>
-                    name = "prettier-vscode";
-                    publisher = "esbenp";
-                    version = "9.3.0"; #taken from marketplace UI
-                    # install without this value, look at error message for calculated sha256.
-                    sha256 = "sha256-hJgPjWf7a8+ltjmXTK8U/MwqgIZqBjmcCfHsAk2G3PA=";
-                  }
-                  {
-                    # taken from the marketplace unique id: <publisher>.<name>
-                    name = "kotlin";
-                    publisher = "mathiasfrohlich";
-                    version = "1.7.1"; #taken from marketplace UI
-                    # install without this value, look at error message for calculated sha256.
-                    sha256 = "sha256-MuAlX6cdYMLYRX2sLnaxWzdNPcZ4G0Fdf04fmnzQKH4=";
-                  }
-                  {
-                    # taken from the marketplace unique id: <publisher>.<name>
-                    name = "terraform";
-                    publisher = "hashicorp";
-                    version = "2.20.0"; #taken from marketplace UI
-                    # install without this value, look at error message for calculated sha256.
-                    sha256 = "sha256-ezMIX7m03y0dhoRLt7xs3zzif2LST3RVQmuUyBKh85s=";
-                  }
-                  {
-                    # taken from the marketplace unique id: <publisher>.<name>
-                    name = "gitlens";
-                    publisher = "eamodio";
-                    version = "12.0.4"; #taken from marketplace UI
-                    # install without this value, look at error message for calculated sha256.
-                    sha256 = "sha256-T39laV6yWu0yKtTT2dmVOriawkrsmE4YqpidWG7OPOg=";
-                  }
-                  {
-                    # taken from the marketplace unique id: <publisher>.<name>
-                    name = "vscode-pull-request-github";
-                    publisher = "github";
-                    version = "0.38.1"; #taken from marketplace UI
-                    # install without this value, look at error message for calculated sha256.
-                    sha256 = "sha256-opR+y818jrdyGGh61swbo0FWKJJCJzn6594km4B76d0=";
-                  }
-                  {
-                    # taken from the marketplace unique id: <publisher>.<name>
-                    name = "code-spell-checker";
-                    publisher = "streetsidesoftware";
-                    version = "2.1.7"; #taken from marketplace UI
-                    # install without this value, look at error message for calculated sha256.
-                    sha256 = "sha256-C0jYDIDBK1JH8eFaFmCUilBXCbU5y2TRF3OZAw9ijoY=";
-                  }
-                  {
-                    # taken from the marketplace unique id: <publisher>.<name>
-                    name = "shellcheck";
-                    publisher = "timonwong";
-                    version = "0.18.9"; #taken from marketplace UI
-                    # install without this value, look at error message for calculated sha256.
-                    sha256 = "sha256-D7lRMmmDgAHKPVyZMC06zNef8UtrgNEE+m0mTbIuc1A=";
-                  }
-                  {
-                    # taken from the marketplace unique id: <publisher>.<name>
-                    name = "vscode-fileutils";
-                    publisher = "sleistner";
-                    version = "3.5.0"; #taken from marketplace UI
-                    # install without this value, look at error message for calculated sha256.
-                    sha256 = "sha256-ulsa8nGNoFRUMVFXN00c9JvF2WeorAhbiCOLAJULVvo=";
-                  }
-                  {
-                    # taken from the marketplace unique id: <publisher>.<name>
-                    name = "vscode-eslint";
-                    publisher = "dbaeumer";
-                    version = "2.2.2"; #taken from marketplace UI
-                    # install without this value, look at error message for calculated sha256.
-                    sha256 = "sha256-llalyQXl+k/ugZq+Ti9mApHRqAGu6QyoMP51GtZnRJ4=";
-                  }
-                  {
-                    # taken from the marketplace unique id: <publisher>.<name>
-                    name = "vscode-docker";
-                    publisher = "ms-azuretools";
-                    version = "1.20.0"; #taken from marketplace UI
-                    # install without this value, look at error message for calculated sha256.
-                    sha256 = "sha256-i3gYTP76YEDItG2oXR9pEXuGv0qmyf1Xv6HQvDBEOyg=";
-                  }
-                  {
-                    # taken from the marketplace unique id: <publisher>.<name>
-                    name = "path-autocomplete";
-                    publisher = "ionutvmi";
-                    version = "1.19.1"; #taken from marketplace UI
-                    # install without this value, look at error message for calculated sha256.
-                    sha256 = "sha256-0hnmCnGgcflA8zFQvaE6iB8eWZIBJZH2plUr40Avtdk=";
-                  }
-                ];
-              };
-              };
-            };*/
           };
         };
       };
@@ -330,11 +149,8 @@
   # $ darwin-rebuild switch -I darwin-config=$HOME/.config/nixpkgs/darwin-configuration.nix
   environment.darwinConfig = "/Users/dsyang/.config/nixpkgs/darwin-configuration.nix";
 
-  # nix.package = pkgs.nix;
-
   # Create /etc/bashrc that loads the nix-darwin environment.
   programs.zsh.enable = true;  # default shell on catalina
-  # programs.fish.enable = true;
 
   # Setup macos system values
   # NOTE: things need to be at default settings (such as keyboard modifiers) for this to take effect
@@ -348,8 +164,6 @@
     };
     primaryUser = "dsyang";
     defaults = {
-      # LaunchServices.LSQuarantine = false;
-
       NSGlobalDomain = {
         PMPrintingExpandedStateForPrint = true;
         PMPrintingExpandedStateForPrint2 = true;

--- a/zshrc-snippets/java-android.zsh
+++ b/zshrc-snippets/java-android.zsh
@@ -1,18 +1,3 @@
-#######
-## java (embeded in Android Studio electric eel+)
-#######
-# export JAVA_HOME="$(/usr/libexec/java_home)"
-# managed by jenv
-# export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
-# export PATH="${JAVA_HOME}/bin:${PATH}"
-
-##########
-## Kotlin
-##########
-# no chmod +x possible with most recent Android Studio
-#export KOTLIN_HOME="/Applications/Android Studio.app/Contents/plugins/Kotlin/kotlinc"
-#export PATH="${KOTLIN_HOME}/bin:${PATH}"
-
 ##########
 ## android
 ##########

--- a/zshrc-snippets/notion.zsh
+++ b/zshrc-snippets/notion.zsh
@@ -53,31 +53,5 @@ export ANDROID_HOME=/Users/dsyang/Library/Android/sdk
 export PATH="$PATH:$ANDROID_HOME/emulator:$ANDROID_HOME/cmdline-tools/latest/bin"
  ### notion android: trust remote emulator adb keys
 export ADB_VENDOR_KEYS="${ADB_VENDOR_KEYS:+$ADB_VENDOR_KEYS:}$HOME/.android/notion-adbkeys"
-## Dont forget to create a nocommit.notion.zsh
-# export BENCHMARK_USER_ID
-# export BENCHMARK_SPACE_ID
-# export BENCHMARK_TOKEN_V2
-
-## Apps
-# 1pass'-
-# Android Studio
-# BetterTouchTool
-# Chrome
-# Clipy
-# DaisyDisk
-# DBeaver
-# Dropbox?x
-# Handbrake
-# iStat Menus?x
-# Kap
-# KeyCastr?
-# Mullvad VPN
-# Open VPN
-# Pixelmator
-# Slack
-# Sublime Text
-# Sublime Merge
-# Testflight
-# VsCode
-# XCode
-# Zoom
+# Machine-local secrets (BENCHMARK_USER_ID/SPACE_ID/TOKEN_V2, etc.) live in
+# the gitignored nocommit.notion.zsh — don't forget to create it on a new machine.


### PR DESCRIPTION
## What

Strips commented-out (dead) code that had accumulated in the config. **No functional change** — only comments are removed. `2 insertions, 229 deletions` across 3 files.

### `darwin-configuration.nix`
- Removed the **~178-line commented-out `/*vscode = {…}*/` block**. VSCode now manages its own settings (disabled back in `39a4acb` "vscode controls itself"), so this was parked, not in use.
- Removed the disabled `#  (builtins.readFile ./zshrc-snippets/flutter.zsh)` and `ocaml.zsh` lines.
- Removed commented-out `nix.package`, `programs.fish.enable`, and `LaunchServices.LSQuarantine` options.

### `zshrc-snippets/java-android.zsh`
- Removed the fully commented-out **Java** and **Kotlin** export sections (JAVA_HOME is managed by jenv; the Kotlin path is no longer settable). Live `android` / `gradle` exports and `android_reverse_ports` are untouched.

### `zshrc-snippets/notion.zsh`
- Removed the commented-out `BENCHMARK_USER_ID/SPACE_ID/TOKEN_V2` export stubs and the dead `## Apps` checklist (superseded by `INSTALLATION.md`). Kept a short two-line pointer to the gitignored `nocommit.notion.zsh`.

## What I deliberately kept

Genuinely useful comments: rationale (`# Set BREW_PREFIX to avoid slow brew --prefix…`), section headers above live code, function docstrings in `misc-functions.zsh`, the perf notes (`saves ~180ms`), and usage examples (`# $ darwin-rebuild switch -I …`).

## Verification

Provably comment-only: for each file I stripped all comments + blank lines from the original and modified versions and diffed — **all three are byte-for-byte identical**. Also brace-balance checked the nix file (depth 0) and confirmed the VSCode block has a single `*/` terminator at the end.

⚠️ No Nix/zsh toolchain in the sandbox, so `nix-instantiate --parse` / `darwin-rebuild` were **not** run — please do the final build on the Mac. Full QA steps are in the explainer doc.

## Notes for review

- Base is `Dans-work-mbp` (cleanup before it becomes `main`).
- Heads-up judgement calls: deleting the big VSCode block, and removing the `## Apps` list. Both are recoverable from git history; easy to veto.

📄 Explainer doc: https://app.notion.com/p/3890a316c2488171b3e0c60b13d251ab
🗂️ Task: https://app.notion.com/p/3890a316c24881198be9c05e0d172b3c